### PR TITLE
Potential fix for code scanning alert no. 1: Use of insecure SSL/TLS version

### DIFF
--- a/tests/servers/test_dot_server.py
+++ b/tests/servers/test_dot_server.py
@@ -90,6 +90,7 @@ def running_dot_server(selfsigned_cert):
 def test_dot_server_roundtrip(running_dot_server):
     host, port = running_dot_server
     ctx = ssl.create_default_context()
+    ctx.minimum_version = ssl.TLSVersion.TLSv1_2
     ctx.check_hostname = False
     ctx.verify_mode = ssl.CERT_NONE
     s = ctx.wrap_socket(socket.socket(), server_hostname="localhost")


### PR DESCRIPTION
Potential fix for [https://github.com/zallison/foghorn/security/code-scanning/1](https://github.com/zallison/foghorn/security/code-scanning/1)

To fix this problem, the SSL context used to create the client connection should be explicitly configured to only allow secure protocol versions, specifically TLSv1.2 or newer. The simplest and preferred approach is to set the context’s `minimum_version` attribute to `ssl.TLSVersion.TLSv1_2` after initializing the context. This attribute is available in Python 3.7 and higher; given the use of other modern features in the codebase, it is likely we can rely on this. No other functionality should change: the context, socket setup, and remainder of the test remain as they are. The change is made by inserting a line after context creation (`ctx = ssl.create_default_context()`) to set `ctx.minimum_version = ssl.TLSVersion.TLSv1_2`.

Only one line (or potentially two, if an import is needed for `ssl.TLSVersion`) needs to be added to the code block in `tests/servers/test_dot_server.py`; no new libraries are needed, and no changes to existing imports are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
