### PR TITLE
Foghorn DNS Release v0.6.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,22 +12,33 @@ All notable changes to this project will be documented in this file.
 - Introduced enhanced DNSSEC-aware behavior in the `resolve.zone_records` plugin, including precomputed mappings for RRsets and RRSIGs and DO-bit-aware responses.
 - Added automatic PTR record generation from A/AAAA records in `resolve.zone_records` when configured.
 - Added an `sshfp_scan` helper script and `ssh_keyscan` utility module for generating SSHFP records from remote hosts.
+- Marked authoritative responses from `resolve.zone_records` as authenticated (AD=1) when they come from signed zones, so DNSSEC-aware stub resolvers and tools like OpenSSH (when combined with `trust-ad`) can rely on them.
 
 ### Changed
 
 - Updated the DNSSEC zone signer helper to normalize zone origins, ensure apex nodes exist, and consistently construct DNSKEY and RRSIG RRsets for signed zones.
 - Refined `resolve.zone_records` DNSSEC handling so RRSIG and DNSKEY data is surfaced only when appropriate and existing behavior is preserved when DNSSEC helpers are unavailable.
+- Improved `resolve.zone_records` DNSSEC answer construction so that, where possible, RRSIGs are attached directly alongside their covered RRsets in the ANSWER section with sensible TTLs.
+
+### Fixed
+
+- Allowed BasePlugin-level options such as `targets`, `targets_domains`, and per-plugin `logging` to flow through the typed `ZoneRecordsConfig` by relaxing its `extra` handling, fixing validation failures for common configs.
+- Fixed SOA synthesis and apex inference for SSHFP-only or partial zones so that `resolve.zone_records` can infer a reasonable zone apex and behave authoritatively (including DNSSEC auto-signing) even when no explicit SOA is present.
+- Normalized DNSSEC owner names for apex DNSKEY/RRSIG RRsets so that signed material is stored under the real zone apex instead of BIND-style `@` owners, ensuring later lookups can find and serve DNSSEC data correctly.
+- Corrected `resolve.zone_records` DNSSEC answer paths so RRSIG records for A/SSHFP and other RRsets are returned in the ANSWER section alongside their covered records and inherit the RRset TTL by default.
+- Updated `resolve.zone_records.pre_resolve` to honor BasePlugin client, listener, and domain targeting helpers (`targets`, `targets_listener`, and `targets_domains`), so zone data is only applied to matching queries.
 
 ### Tests
 
-- Extended `tests/plugins/test_zone_records.py` to cover DNSSEC mappings, DO-bit behavior, SOA synthesis for SSHFP-only zones, and automatic PTR generation.
+- Extended `tests/plugins/test_zone_records.py` to cover DNSSEC mappings, DO-bit behavior, SOA synthesis, automatic PTR generation, and the new targeting/normalization behaviors.
 - Added tests for the new `sshfp_scan` script and `ssh_keyscan` utility under `tests/scripts`, validating SSHFP output and error handling.
 
 ### Documentation
 
 - Updated Makefile documentation to match current targets and DNSSEC/tooling helpers.
-- Refreshed `zone_records` plugin documentation to describe DNSSEC, PTR auto-generation, and SSHFP interactions.
+- Refreshed `zone_records` plugin documentation to describe DNSSEC, PTR auto-generation, targeting, and SSHFP interactions.
 - Updated Pihole and RFC-style documentation to reflect the new DNSSEC tooling and behavior.
+- Documented glibc `trust-ad` behavior in `README.md`, including how to configure `/etc/resolv.conf` so glibc-based applications such as OpenSSH can accept the AD bit from a validating Foghorn instance.
 
 ## [0.6.2] - 2026-01-17
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,33 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.6.3] - 2026-01-19
+
+> Release notes for changes between **v0.6.2** and **v0.6.3**.
+
+### Added
+
+- Added configurable DNSSEC signing for zones via a new `ZoneDnssecSigningConfig` block, including algorithm selection, keys directory, enable/disable flag, and validity controls.
+- Introduced enhanced DNSSEC-aware behavior in the `resolve.zone_records` plugin, including precomputed mappings for RRsets and RRSIGs and DO-bit-aware responses.
+- Added automatic PTR record generation from A/AAAA records in `resolve.zone_records` when configured.
+- Added an `sshfp_scan` helper script and `ssh_keyscan` utility module for generating SSHFP records from remote hosts.
+
+### Changed
+
+- Updated the DNSSEC zone signer helper to normalize zone origins, ensure apex nodes exist, and consistently construct DNSKEY and RRSIG RRsets for signed zones.
+- Refined `resolve.zone_records` DNSSEC handling so RRSIG and DNSKEY data is surfaced only when appropriate and existing behavior is preserved when DNSSEC helpers are unavailable.
+
+### Tests
+
+- Extended `tests/plugins/test_zone_records.py` to cover DNSSEC mappings, DO-bit behavior, SOA synthesis for SSHFP-only zones, and automatic PTR generation.
+- Added tests for the new `sshfp_scan` script and `ssh_keyscan` utility under `tests/scripts`, validating SSHFP output and error handling.
+
+### Documentation
+
+- Updated Makefile documentation to match current targets and DNSSEC/tooling helpers.
+- Refreshed `zone_records` plugin documentation to describe DNSSEC, PTR auto-generation, and SSHFP interactions.
+- Updated Pihole and RFC-style documentation to reflect the new DNSSEC tooling and behavior.
+
 ## [0.6.2] - 2026-01-17
 
 > Release notes for changes between **v0.6.1** and **v0.6.2**.

--- a/Makefile
+++ b/Makefile
@@ -63,7 +63,7 @@ vars-print-all: vars-make vars-docker vars-ssl vars-python
 # Print a variable by name: make var-print-FOO
 .PHONY: var-print-%
 var-print-%:
-	@echo "- $* is a $(flavor $*) var set to [$($*)]"
+	@printf "%-15s= %s\n" "$*" "$($*)"
 
 # Header sections
 .PHONY: vars-header-%

--- a/README.md
+++ b/README.md
@@ -256,6 +256,18 @@ rebuilds the function's cache at startup so you can switch between
 configuration.
 - `server.dnssec`
   - Mode and DNSSEC validation knobs (e.g., UDP payload size).
+
+#### glibc, `trust-ad`, and the DNSSEC AD bit
+
+On Linux systems that use glibc, applications (including `ssh` when using SSHFP records) only see the DNSSEC AD bit when the resolver is explicitly configured to trust it. If you run Foghorn (or another validating resolver that honors the upstream AD bit) and want glibc clients to accept that AD as trustworthy, point `/etc/resolv.conf` at Foghorn and add `trust-ad` to the options line:
+
+```text
+nameserver 127.0.0.1
+options edns0 trust-ad
+```
+
+Without `trust-ad`, glibc clears the AD flag before handing answers to applications, so tools like OpenSSH will ignore SSHFP records even when Foghorn has validated them.
+
 - `server.enable_ede`
   - Optional toggle for RFC 8914 Extended DNS Errors; when true and the client advertises EDNS(0), Foghorn can attach EDE options to certain policy or upstream-failure responses and surface per-code stats in the admin UI.
 - `server.resolver`

--- a/assets/config-schema.json
+++ b/assets/config-schema.json
@@ -1210,6 +1210,69 @@
               ],
               "title": "AxfrZoneConfig",
               "type": "object"
+            },
+            "ZoneDnssecSigningConfig": {
+              "additionalProperties": false,
+              "description": "Brief: DNSSEC auto-signing configuration for ZoneRecords.\n\nInputs:\n  - enabled: Enable automatic DNSSEC signing for authoritative zones.\n  - keys_dir: Optional base directory for per-zone key files.\n  - algorithm: DNSSEC algorithm name (e.g. \"ECDSAP256SHA256\").\n  - generate: Key generation policy (\"yes\", \"no\", or \"maybe\").\n  - validity_days: Signature validity window in days.\n  - use_tld: Optional single-label TLD (e.g. \"zaa\", \"corp\") to treat as\n    an inferred apex for SSHFP-only zones when synthesizing SOA records.\n\nOutputs:\n  - Parsed ZoneDnssecSigningConfig instance used by the config schema.",
+              "properties": {
+                "algorithm": {
+                  "default": "ECDSAP256SHA256",
+                  "description": "DNSSEC algorithm name (e.g. 'ECDSAP256SHA256', 'RSASHA256'). Default: \"ECDSAP256SHA256\".",
+                  "title": "Algorithm",
+                  "type": "string"
+                },
+                "enabled": {
+                  "default": false,
+                  "description": "Enable automatic DNSSEC signing for authoritative zones. Default: false.",
+                  "title": "Enabled",
+                  "type": "boolean"
+                },
+                "generate": {
+                  "default": "maybe",
+                  "description": "Key generation policy: 'yes' (always new), 'no' (never), 'maybe' (generate when missing). Default: \"maybe\".",
+                  "title": "Generate",
+                  "type": "string"
+                },
+                "keys_dir": {
+                  "anyOf": [
+                    {
+                      "description": "Type: string.",
+                      "type": "string"
+                    },
+                    {
+                      "description": "Type: null.",
+                      "type": "null"
+                    }
+                  ],
+                  "default": null,
+                  "description": "Directory to read/write DNSSEC keys; defaults to the working directory when omitted.",
+                  "title": "Keys Dir"
+                },
+                "use_tld": {
+                  "anyOf": [
+                    {
+                      "description": "Type: string.",
+                      "type": "string"
+                    },
+                    {
+                      "description": "Type: null.",
+                      "type": "null"
+                    }
+                  ],
+                  "default": null,
+                  "description": "Optional single-label TLD (e.g. 'zaa', 'corp') that ZoneRecords may treat as an inferred zone apex when synthesizing SOA records for SSHFP-only data.",
+                  "title": "Use Tld"
+                },
+                "validity_days": {
+                  "default": 30,
+                  "description": "Signature validity window in days. Default: 30.",
+                  "minimum": 1,
+                  "title": "Validity Days",
+                  "type": "integer"
+                }
+              },
+              "title": "ZoneDnssecSigningConfig",
+              "type": "object"
             }
           },
           "additionalProperties": false,
@@ -1249,6 +1312,18 @@
               ],
               "default": null,
               "title": "Bind Paths"
+            },
+            "dnssec_signing": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/ZoneDnssecSigningConfig"
+                },
+                {
+                  "description": "Type: null.",
+                  "type": "null"
+                }
+              ],
+              "default": null
             },
             "file_paths": {
               "anyOf": [

--- a/docs/MAKEFILE.md
+++ b/docs/MAKEFILE.md
@@ -8,43 +8,109 @@ The `Makefile` lives at the repo root and uses a few configurable variables:
 - `PREFIX` – Docker image repository/namespace prefix (default: current `$USER`).
 - `CONTAINER_NAME` – Docker image/container base name (default: `foghorn`).
 - `TAG` – Docker image tag (default: `latest`).
+- `KEYDIR` – Directory where SSL keys and certificates are stored (default: `./keys`).
 
 `make` defaults to the `help` target (`.DEFAULT_GOAL := help`), so running `make` with no arguments prints a summary.
 
 ---
 
+## All targets (index)
+
+_Local/dev_
+- `env`
+- `env-dev`
+- `run`
+- `schema`
+
+_Testing_
+- `test`
+- `tests`
+
+_Variable inspection_
+- `vars-print-all-all`
+- `vars-print-all`
+- `var-print-%`
+- `vars-header-%`
+- `vars-make`
+- `vars-docker`
+- `vars-ssl`
+- `vars-python`
+
+_DNSSEC_
+- `dnssec-sign-zone`
+
+_SSL / OpenSSL keys_
+- `ssl-key-dir`
+- `ssl-ca`
+- `ssl-ca-pem`
+- `ssl-cert`
+- `ssl-cert-pem`
+- `ssl-clean-keys`
+
+_Git / GitHub helpers_
+- `github-push`
+- `create-pr`
+
+_Docker helpers_
+- `docker`
+- `docker-build`
+- `docker-clean`
+- `docker-run`
+- `docker-run-not-host`
+- `docker-logs`
+- `docker-ship`
+
+_Packaging_
+- `package-build`
+- `package-publish`
+- `package-publish-dev`
+
+_Misc_
+- `help`
+
+---
+
 ## Overview
 
-### Building
+### Local development
 
-The Makefile supports building and running directly, or via docker. The highlights are:
+The main entry points for local development are:
 
-- Build and run locally
-```sh
+- Create a virtualenv and install the project (with dev extras):
+  ```sh
+  make env-dev
+  ```
+- Run Foghorn locally from the venv:
+  ```sh
   make run
-```
-- Build and run using docker
-```sh
-  make docker-run
-```
+  ```
+- Run the test suite with coverage:
+  ```sh
+  make test
+  # or
+  make tests
+  ```
 
-#### All targets
-```
-  run            – Execute foghorn --config config.yaml (depends on build)
-  env            – Create virtual environment in ./venv
-  build          – Install project in editable mode (with dev dependencies) into ./venv
-  test           – Run pytest with coverage
-  clean          – Remove venv/, var/, build/, and temp files
-  docker         – Clean image, build it, run container, then follow logs
-  docker-build   – Build docker image zack/foghorn:latest
-  docker-clean   – Remove docker image zack/foghorn:latest
-  docker-run     – Run docker container (ports 53, 5380/tcp, 8153/tcp )
-  docker-logs    – Follow docker container logs
-  docker-dev-ship       – Clean, build, and push docker image to docker hub
-```
+### Docker
 
-For real deployments use `docker-compose.yaml` file to manage the container, after it's been built.
+To build and run using Docker:
 
+- Build the image:
+  ```sh
+  make docker-build
+  ```
+- Run the container and follow logs (host networking):
+  ```sh
+  make docker
+  ```
+- Run the container with explicit port mappings instead of `--net=host`:
+  ```sh
+  make docker-run-not-host
+  ```
+
+For production-like deployments, you will typically use `docker-compose.yaml` (or your own orchestration) with the image produced by `docker-build`/`docker-ship`.
+
+---
 
 ## Variables
 
@@ -55,30 +121,34 @@ The `VENV` variable controls where the Python virtual environment is created and
 - Default: `./venv`
 - Used in:
   - `env`
-  - `build`
-  - indirectly in `run` and `test` when they create a venv before running commands.
+  - `env-dev`
+  - `run`
+  - `test` / `tests`
 
 You can override it per invocation:
 
 ```sh
-make VENV=.venv env
+make VENV=.venv env-dev
 ```
 
 > Note: Most project tooling and docs assume the default `venv` directory.
 
-### Docker: `PREFIX`, `CONTAINER_NAME`, and `TAG`
+### Docker: `PREFIX`, `CONTAINER_NAME`, `TAG`, ports, and data
 
-These variables control Docker image names and tags:
+These variables control Docker image names and runtime behavior:
 
 - `PREFIX` (default: `${USER}`)
   - Acts as the image repository/namespace.
   - For example, if your username is `zack`, the image name becomes `zack/foghorn:latest`.
-  - You can set it to a registry or org, e.g. `PREFIX=my-registry.example.com/foghorn`.
 - `CONTAINER_NAME` (default: `foghorn`)
   - Base name of the image and the running container.
-  - The container is run with `--name foghorn` in `docker-run`.
+  - The container is run with `--name foghorn` in `docker-run` / `docker-run-not-host`.
 - `TAG` (default: `latest`)
   - The Docker image tag.
+- `CONTAINER_DATA` (default: `./.docker`)
+  - Directory mounted into the container to hold configuration and data.
+- `UDPPORT`, `TCPPORT`, `ADMINPORT` (defaults: `53`, `53`, `8053`)
+  - Control the host ports used by `docker-run-not-host`.
 
 The full image reference used by Docker targets is:
 
@@ -99,306 +169,193 @@ These values are used consistently in:
 
 - `docker-build` – builds the image `${PREFIX}/${CONTAINER_NAME}:${TAG}`
 - `docker-clean` – removes the same image
-- `dev-ship` – pushes `${PREFIX}/${CONTAINER_NAME}:${TAG}`
+- `docker-ship` – pushes `${PREFIX}/${CONTAINER_NAME}:${TAG}`
+
+### SSL variables
+
+The SSL-related targets use:
+
+- `KEYDIR` (default: `./keys`) – where CA/server keys and certs live.
+- `CNAME` – Common Name for the server certificate (defaults to `hostname`).
+- `CA_KEY`, `CA_CERT`, `CA_PEM` – paths for the CA key/cert/PEM.
+- `SERVER`, `SERVER_PEM` – base path and PEM for the server certificate and key.
+
+You normally do not need to override these; the defaults are suitable for local development.
 
 ---
 
 ## Targets
 
-### `run`
+Below is a list of all `Makefile` targets, grouped roughly by purpose.
 
-```make
-run: build
-    python -m venv $(VENV) && . ${VENV}/bin/activate || true
-    mkdir var 2>/dev/null || true
-    foghorn --config config.yaml
-```
+### Local running and environment
 
-**Purpose:** Build the project (via `build`), ensure a virtual environment directory exists, create a `var/` directory, and run Foghorn using `config.yaml`.
+- `run`
+  - Depends on: `$(VENV)/bin/foghorn`
+  - Activates the venv, ensures `var/` exists, then runs:
+    ```sh
+    foghorn --config config/config.yaml
+    ```
+- `env`
+  - Creates the virtual environment in `$(VENV)` if it does not already exist and installs the package once.
+- `env-dev`
+  - Depends on: `env`
+  - Installs the project in editable mode with dev dependencies (`.[dev]`) into `$(VENV)`.
+- `schema`
+  - Regenerates `assets/config-schema.json` from the Python schema generator.
+  - Implementation detail: runs `./scripts/generate_foghorn_schema.py -o assets/config-schema.json` and then appends a trailing newline.
 
-- Depends on `build`, so it will:
-  1. Create/refresh the venv.
-  2. Install Foghorn in editable mode with dev extras.
-- Then it runs:
-  - `foghorn --config config.yaml`
+### DNSSEC
 
-Usage:
+- `dnssec-sign-zone`
+  - Depends on: `$(VENV)/bin/foghorn`
+  - Signs a zone file and writes a fully DNSSEC-signed output zonefile.
+  - Required environment variables:
+    - `ZONE` – Zone name (e.g. `example.com.`).
+    - `INPUT` – Path to the unsigned zone file.
+    - `OUTPUT` – Path to the signed zone file.
+  - Optional variables:
+    - `KEYS_DIR` – Directory for DNSSEC keys (default: `./keys`).
+    - `ALGO` – Signing algorithm (default: `ECDSAP256SHA256`).
+    - `VALIDITY_DAYS` – Signature validity period (default: `30`).
 
-```sh
-make run
-```
-
-### `env`
-
-```make
-env:
-    @echo "=== Creating virtual environment ==="
-    python -m venv $(VENV) || true
-```
-
-**Purpose:** Create the Python virtual environment in `$(VENV)` if needed .
-
-
-Usage:
-
-```sh
-make env
-```
-
-### `build`
-
-```make
-build: env
-    @echo "=== Installing project in editable mode ==="
-    source ${VENV}/bin/activate
-    $(VENV)/bin/pip install -e ".[dev]"
-```
-
-**Purpose:** Create the venv (via `env`) and install Foghorn into it in editable mode with development dependencies.
-
-- Calls `pip install -e '.[dev]'` inside `$(VENV)`.
-- This is the preferred way to set up your development environment before running tests or the CLI.
-
-Usage:
+Example usage:
 
 ```sh
-make build
+make dnssec-sign-zone \
+  ZONE=example.com. \
+  INPUT=unsigned.zone \
+  OUTPUT=signed.zone \
+  KEYS_DIR=./keys \
+  ALGO=ECDSAP256SHA256 \
+  VALIDITY_DAYS=30
 ```
 
-### `test` / `tests`
+### Variable inspection
 
-```make
-.PHONY: test tests
-tests: test
+These targets help you inspect the `Makefile` variables:
 
-test: env
-    @echo "=== Running tests (short) ==="
-    source ${VENV}/bin/activate
-    pytest --cov=foghorn tests
-```
+- `vars-print-all-all`
+  - Prints all make variables (mostly for debugging/introspection).
+- `vars-print-all`
+  - Prints foghorn-related variables grouped by category (Make, Docker, SSL, Python).
+- `var-print-FOO` (pattern: `var-print-%`)
+  - Prints flavor and value of a single variable, e.g. `make var-print-VENV`.
 
-**Purpose:** Run the test suite with coverage.
+There are also internal helper targets used by those commands:
 
-- `tests` is an alias that simply calls `test`.
-- `test`:
-  - Ensures a virtual environment directory exists (similar pattern to `run`).
-  - Runs `pytest --cov=foghorn tests`.
+- `vars-header-%` – prints a header for a group of variables.
+- `vars-make` – prints Make-related variables.
+- `vars-docker` – prints Docker-related variables.
+- `vars-ssl` – prints SSL-related variables.
+- `vars-python` – prints Python-related variables.
 
-Usage:
+### Testing
 
-```sh
-make test
-# or
-make tests
-```
+- `test`
+  - Depends on: `$(VENV)/bin/foghorn`, `env-dev`
+  - Activates the venv and runs:
+    ```sh
+    pytest --cov=src --cov-report=json --ff tests
+    ```
+  - Updates the coverage badge in `README.md` using the JSON coverage report and prints a short coverage summary.
+- `tests`
+  - Alias for `test`.
 
-### `clean`
+### Cleaning
 
-```make
-clean:
-    @echo "=== Removing virtual environment and var directory ==="
-    rm -rf $(VENV) var build
-    @echo "=== Removing temporary files and byte‑code ==="
-    find . -type d -name "__pycache__" -exec rm -rf {} +;
-    find . -type f \
-        \( -name '*.pyc' -o -name '*.tmp' -o -name '*~' -o -name '#*' -o -name '*.swp' \) -delete
-```
+- `clean`
+  - Removes:
+    - `$(VENV)`
+    - `var/`
+    - `build/`
+    - `docker-build/`
+    - `coverage.json`
+    - `schema.json`
+    - `dist/`
+  - Also removes Python bytecode and common temporary/editor files:
+    - `__pycache__/` directories
+    - `*.pyc`, `*.tmp`, backup (`*~`, `#*`), and swap (`*.swp`) files.
 
-**Purpose:** Remove local build artifacts and temporary files.
+### SSL / OpenSSL keys
 
-- Deletes:
-  - The virtualenv directory `$(VENV)`
-  - `var/`
-  - `build/`
-- Cleans up Python and editor artifacts:
-  - `__pycache__/`
-  - `*.pyc`, `*.tmp`, backup (`*~`, `#*`), and swap (`*.swp`) files.
+These targets help you create a simple CA and server certificate for local use.
 
-Usage:
+- `ssl-key-dir`
+  - Ensures `KEYDIR` exists.
+- `ssl-ca`
+  - Depends on: `ssl-key-dir`, `$(CA_CERT)`
+  - Creates the CA key and certificate if missing.
+- `ssl-ca-pem`
+  - Depends on: `ssl-ca`, `$(CA_PEM)`
+  - Produces a PEM-encoded CA certificate (trust anchor).
+- `ssl-cert`
+  - Depends on: `ssl-key-dir`, `${SERVER}.crt`
+  - Creates a key and certificate for the server (CN=`${CNAME}`).
+- `ssl-cert-pem`
+  - Depends on: `ssl-cert`, `$(SERVER_PEM)`
+  - Produces a combined server PEM containing both certificate and key.
+- `ssl-clean-keys`
+  - Deletes generated keys, CSRs, certs, and serial files from `KEYDIR`.
 
-```sh
-make clean
-```
+### Git / GitHub helpers
 
----
+- `github-push`
+  - Depends on: `clean`, `tests`
+  - Ensures the repository is clean (no uncommitted or untracked changes) and then pushes the current branch to `origin`.
+- `create-pr`
+  - Uses the GitHub API to open a PR for the current branch.
+  - Expects a `GITHUB_TOKEN` environment variable (Base64-encoded in this implementation).
+  - PR title/body are built from the branch name and recent commits.
 
-## Docker targets
+> These helpers are opinionated and may need adjustment for your own workflow.
 
-These targets assume you have Docker installed and that you are comfortable running a container that binds to port 53 on the host.
+### Docker helpers
 
-### Image naming with `PREFIX` and `TAG`
+- `docker`
+  - Depends on: `clean`, `docker-build`, `docker-run`, `docker-logs`
+  - Convenience wrapper that cleans, builds the image, runs the container, and then tails logs.
+- `docker-build`
+  - Syncs a subset of the repo into `docker-build/` (excluding `__pycache__`) and builds the image `${PREFIX}/${CONTAINER_NAME}:${TAG}` from that directory.
+- `docker-clean`
+  - Removes the image `${PREFIX}/${CONTAINER_NAME}:${TAG}` if it exists and deletes the `docker-build/` directory.
+- `docker-run`
+  - Depends on: `docker-build`
+  - Runs the container with `--net=host`, mounting `${CONTAINER_DATA}` as `/foghorn/config/`, labeling it for discovery, mounting `/etc/hosts`, and using `--restart unless-stopped`.
+- `docker-run-not-host`
+  - Depends on: `docker-build`
+  - Runs the container without `--net=host`, instead mapping:
+    - `${UDPPORT}:5333/udp`
+    - `${TCPPORT}:5333/tcp`
+    - `${ADMINPORT}:8053/tcp`
+- `docker-logs`
+  - Follows the logs of the `foghorn` container.
+- `docker-ship`
+  - Depends on: `clean`, `docker-build`
+  - Pushes the image `${PREFIX}/${CONTAINER_NAME}:${TAG}` to the configured registry/namespace.
 
-All image-related targets refer to the same image:
+### Packaging
 
-```text
-${PREFIX}/${CONTAINER_NAME}:${TAG}
-```
-
-- `PREFIX` defaults to `${USER}` – you can change it per call:
-  - `make PREFIX=myorg TAG=0.2.0 docker-build`
-- `TAG` defaults to `latest` but can be set to any tag (e.g. a version or branch name).
-- `CONTAINER_NAME` defaults to `foghorn`.
-
-This is used consistently in `docker-build`, `docker-clean`, and `docker-dev-ship`.
-
-### `docker`
-
-```make
-.PHONY: docker
-docker: docker-build docker-run docker-logs
-```
-
-**Purpose:** Convenience target to build an image, run a container, and then follow its logs.
-
-- Runs, in order:
-  1. `docker-build`
-  2. `docker-run`
-  3. `docker-logs`
-
-Usage:
-
-```sh
-make docker
-```
-
-### `docker-build`
-
-```make
-docker-build: docker-clean
-    docker build . -t ${PREFIX}/${CONTAINER_NAME}:${TAG}
-```
-
-**Purpose:** Build the Foghorn Docker image.
-
-- First calls `docker-clean` to remove any existing image with the same name.
-- Then builds a new image from the local `Dockerfile` with tag `${PREFIX}/${CONTAINER_NAME}:${TAG}`.
-
-Examples:
-
-```sh
-# Default image, e.g. zack/foghorn:latest
-make docker-build
-
-# Custom org / tag
-make PREFIX=myorg TAG=0.2.0 docker-build
-```
-
-### `docker-clean`
-
-```make
-docker-clean:
-    docker rmi -f ${PREFIX}/${CONTAINER_NAME}:${TAG} || true
-```
-
-**Purpose:** Remove the Docker image used for this project.
-
-- Uses `docker rmi -f` to force removal, ignoring errors (e.g. image missing).
-- Targets the same image name as `docker-build` and `docker-dev-ship`.
-
-Usage:
-
-```sh
-make docker-clean
-```
-
-### `docker-run`
-
-```make
-docker-run:
-    docker rm -f foghorn 2> /dev/null
-    docker run --name foghorn -d \
-        -p 53:5335/udp \
-        -p 53:53/tcp \
-        -p 5380:5380/tcp \
-        -v /etc/hosts:/etc/hosts:ro \
-        --restart unless-stopped \
-        ${PREFIX}/${CONTAINER_NAME}:${TAG}
-```
-
-**Purpose:** Run the Foghorn container with useful defaults.
-
-- Removes any existing container named `foghorn`.
-- Starts a new detached container named `foghorn` from the image `${PREFIX}/${CONTAINER_NAME}:${TAG}`.
-- Port mappings:
-  - `-p 53:5335/udp` – host UDP port 53 → container UDP 5335 (DNS listener).
-  - `-p 53:53/tcp` – host TCP port 53 → container TCP 53 (TCP DNS, if used).
-  - `-p 8053:8053/tcp` – host TCP port 8053 → container TCP 8053 (admin/web server).
-- Mounts `/etc/hosts` read-only into the container.
-- Uses `--restart unless-stopped` so the container is automatically restarted by Docker.
-
-Usage:
-
-```sh
-make docker-run
-```
-
-> You may need elevated privileges or appropriate capabilities to bind to port 53 on the host.
-
-### `docker-logs`
-
-```make
-docker-logs:
-    docker logs -f foghorn
-```
-
-**Purpose:** Follow the logs of the running `foghorn` container.
-
-Usage:
-
-```sh
-make docker-logs
-```
-
-### `docker-dev-ship`
-
-```make
-dev-ship: clean docker-build
-    docker push ${PREFIX}/${CONTAINER_NAME}:${TAG}
-```
-
-**Purpose:** Clean your local environment, rebuild the Docker image, and push it to the configured registry/namespace.
-
-- Runs:
-  1. `clean` – remove venv, temp files, etc.
-  2. `docker-build` (via dependency)
-  3. `docker push ${PREFIX}/${CONTAINER_NAME}:${TAG}`
-
-Typical usage:
-
-```sh
-# Push zack/foghorn:latest
-make dev-ship
-
-# Push myorg/foghorn:0.2.0
-make PREFIX=myorg TAG=0.2.0 dev-ship
-```
+- `package-build`
+  - Depends on: `env-dev`
+  - Builds the Python package into `dist/` using `python -m build`.
+- `package-publish`
+  - Depends on: `package-build`
+  - Uploads the built distributions to PyPI using `twine upload`.
+- `package-publish-dev`
+  - Depends on: `package-build`
+  - Uploads the built distributions to TestPyPI using `twine upload --repository testpypi`.
 
 ---
 
 ## `help`
 
-```make
-help:
-    @echo "Makefile targets:"
-    @echo "  run            – Execute foghorn --config config.yaml (depends on build)"
-    @echo "  env            – Create virtual environment in $(VENV)"
-    @echo "  build          – Install project in editable mode (with dev dependencies) into $(VENV)"
-    @echo "  test           – Run pytest with coverage"
-    @echo "  clean          – Remove venv/, var/, build/, and temp files"
-    @echo "  docker         – Clean image, build it, run container, then follow logs"
-    @echo "  docker-build   – Build docker image ${PREFIX}/${CONTAINER_NAME}:${TAG}"
-    @echo "  docker-clean   – Remove docker image ${PREFIX}/${CONTAINER_NAME}:${TAG}"
-    @echo "  docker-run     – Run docker container (ports 53/udp, 53/tcp, 5380/tcp)"
-    @echo "  docker-logs    – Follow docker container logs"
-    @echo "  docker-dev-ship       – Clean, build, and push docker image ${PREFIX}/${CONTAINER_NAME}:${TAG}"
-```
-
-**Purpose:** Default entry point (`make` with no arguments). Prints a one-line description of each supported target, including how Docker image names are derived from `PREFIX`, `CONTAINER_NAME`, and `TAG`.
-
-Usage:
+The default `help` target prints a categorized summary of the most important targets and what they do. Running either of the following will show the same output:
 
 ```sh
 make
 # or
 make help
 ```
+
+The `help` text is the authoritative, up-to-date short reference. This document provides the longer description of each target and the variables they use.

--- a/docs/RFCs.md
+++ b/docs/RFCs.md
@@ -250,12 +250,12 @@ Example plugin entry (YAML):
 
 ```yaml
 plugins:
-  - name: example-zones
-	plugin: zone_records
-	config:
-	  bind_paths:
-		- /etc/foghorn/zones/example.com.zone
-		- /etc/foghorn/zones/example.net.zone
+  - id: example-zones
+    type: zone_records
+    config:
+      bind_paths:
+        - /etc/foghorn/zones/example.com.zone
+        - /etc/foghorn/zones/example.net.zone
 
 	  # Optional: additional inline records in the custom pipe-delimited format
 	  records:
@@ -300,21 +300,21 @@ DoT example:
 
 ```yaml
 plugins:
-  - name: example-zones-dot
-	plugin: zone_records
-	config:
-	  axfr_zones:
-		- zone: example.com
-		  upstreams:
-			- host: 192.0.2.10
-			  port: 53
-			  transport: tcp
-			- host: 2001:db8::1
-			  port: 853
-			  transport: dot
-			  server_name: axfr.example.com
-			  verify: true
-			  ca_file: /etc/ssl/certs/ca-bundle.crt
+  - id: example-zones-dot
+    type: zone_records
+    config:
+      axfr_zones:
+        - zone: example.com
+          upstreams:
+            - host: 192.0.2.10
+              port: 53
+              transport: tcp
+            - host: 2001:db8::1
+              port: 853
+              transport: dot
+              server_name: axfr.example.com
+              verify: true
+              ca_file: /etc/ssl/certs/ca-bundle.crt
 ```
 
 ### 7.2 DNSSEC for Synthetic Zones

--- a/docs/plugins/resolve/zone_records.md
+++ b/docs/plugins/resolve/zone_records.md
@@ -205,6 +205,10 @@ Clients without DO=1 receive only the base RRsets without signatures.
 - Zone apex SOA records are tracked separately for SOA queries and are used to
   build proper NOERROR/NODATA and NXDOMAIN authority sections for names inside
   authoritative zones.
+- A and AAAA RRsets automatically synthesize reverse PTR records whose
+  owners follow `ipaddress.ip_address(...).reverse_pointer` semantics and
+  whose targets point back to the forward owner name. Explicit PTR records
+  retain precedence: they define the TTL and are not overwritten.
 - Zone transfers (AXFR/IXFR) are fetched via the optional `axfr_zones` config at
   startup; subsequent reloads only use local files and inline records.
 - When a zone apex carries an SOA record (from any source), ZoneRecords marks

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "foghorn"
-version = "0.6.1"
+version = "0.6.3"
 description = "Foghorn is a fast, pluggable DNS server that caches, filters, routes, and bends DNS to your will. Up- and down-stream UDP, TCP, DoT, and DoH. DNSEC. Because DNS should do what you want."
 
 authors = [ { name = "Zack Allison", email = "zack@zackallison.com" } ]

--- a/scripts/sshfp_scan.py
+++ b/scripts/sshfp_scan.py
@@ -1,0 +1,154 @@
+#!/usr/bin/env python3
+"""Paramiko-based SSHFP key scanner CLI wrapper.
+
+Brief:
+  Given a hostname (and optional port), or a CIDR such as ``192.0.2.0/24``,
+  connects using multiple host key algorithms and prints SSHFP records
+  equivalent to ``ssh-keyscan -D <host>``.
+
+Inputs:
+  - Command-line arguments; see ``parse_args`` for details.
+
+Outputs:
+  - Prints one or more ``<hostname> IN SSHFP <alg> <fptype> <fingerprint>``
+    lines to stdout and returns an exit status code.
+"""
+
+import argparse
+import ipaddress
+import sys
+from typing import List, Optional
+
+from foghorn.utils import ssh_keyscan
+
+
+def parse_args(argv: Optional[List[str]] = None) -> argparse.Namespace:
+    """Parse command-line arguments.
+
+    Inputs:
+      argv: Optional list of argument strings (defaults to sys.argv[1:]).
+
+    Outputs:
+      An argparse.Namespace with attributes: targets, port, timeout,
+      zone_record_format, zone_ttl.
+    """
+    parser = argparse.ArgumentParser(
+        description="Scan SSH host keys and print DNS SSHFP records "
+        "(similar to ssh-keyscan -D).",
+    )
+    parser.add_argument(
+        "targets",
+        nargs="+",
+        help=(
+            "One or more hostnames, IP addresses, or CIDR ranges "
+            "(e.g. lemur.zaa, 192.0.2.10, 192.0.2.0/24)."
+        ),
+    )
+    parser.add_argument(
+        "-p",
+        "--port",
+        type=int,
+        default=22,
+        help="SSH port (default: 22).",
+    )
+    parser.add_argument(
+        "-t",
+        "--timeout",
+        type=float,
+        default=5.0,
+        help="Connection and handshake timeout in seconds (default: 5.0).",
+    )
+    parser.add_argument(
+        "--zone-record-format",
+        action="store_true",
+        help=(
+            'When set, print records as "<domain>|SSHFP|<ttl>|<value>" lines '
+            "suitable for the ZoneRecords plugin, where <value> is "
+            '"<alg> <fptype> <fingerprint>" and <ttl> comes from --zone-ttl.'
+        ),
+    )
+    parser.add_argument(
+        "--zone-ttl",
+        type=int,
+        default=300,
+        help="TTL to use for --zone-format output (default: 300).",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    """Entry point: parse arguments, collect SSHFP records, print them.
+
+    Inputs:
+      - argv: Optional list of CLI arguments (defaults to ``sys.argv[1:]``).
+
+    Outputs:
+      - int: Zero on success, non-zero on error.
+    """
+
+    args = parse_args(argv)
+
+    # Accept one or more hostnames/IPs, and/or CIDRs such as ``192.0.2.0/24``,
+    # and expand CIDRs to individual IP addresses.
+    targets: List[str] = []
+    for raw_arg in args.targets:
+        raw = str(raw_arg)
+        if "/" in raw:
+            try:
+                network = ipaddress.ip_network(raw, strict=False)
+            except ValueError as exc:  # pragma: no cover - CLI validation
+                print(f"Invalid CIDR {raw!r}: {exc}", file=sys.stderr)
+                return 2
+            cidr_hosts = [str(ip) for ip in network.hosts()]
+            if not cidr_hosts:
+                print(
+                    f"CIDR {raw!r} did not contain any host addresses",
+                    file=sys.stderr,
+                )
+                return 1
+            targets.extend(cidr_hosts)
+        else:
+            targets.append(raw)
+
+    any_records = False
+    for host in targets:
+        records = ssh_keyscan.collect_sshfp_records(
+            hostname=host,
+            port=int(args.port),
+            timeout=float(args.timeout),
+        )
+
+        if not records:
+            print(f"No SSHFP records found for {host}", file=sys.stderr)
+            continue
+
+        any_records = True
+        for line in records:
+            if not args.zone_record_format:
+                print(line)
+                continue
+
+            # Expect lines in the form:
+            #   "<hostname> IN SSHFP <alg> <fptype> <fingerprint>"
+            parts = str(line).split()
+            if len(parts) < 6:
+                # Fallback: emit the original line when the format is
+                # unexpected, rather than raising.
+                print(line)
+                continue
+
+            owner, maybe_in, qtype_token = parts[0], parts[1], parts[2]
+            if maybe_in.upper() != "IN" or qtype_token.upper() != "SSHFP":
+                print(line)
+                continue
+
+            domain = owner.rstrip(".").lower()
+            ttl = int(getattr(args, "zone_ttl", 300) or 300)
+            rdata = " ".join(parts[3:])
+            print(f"{domain}|SSHFP|{ttl}|{rdata}")
+
+    return 0 if any_records else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/foghorn/plugins/resolve/zone_records.py
+++ b/src/foghorn/plugins/resolve/zone_records.py
@@ -1353,8 +1353,8 @@ class ZoneRecords(BasePlugin):
         # Build a helper mapping that groups RRsets by qtype and owner name
         # and, when RRSIGs exist for a particular RRset, associates the RRSIG
         # records with the covered qtype. This is used at query time to build
-        # answer sections and attach the corresponding RRSIGs as additional
-        # records without having to re-parse textual representations.
+        # answer sections and attach the corresponding RRSIGs alongside their
+        # covered RRsets without having to re-parse textual representations.
         try:
             try:
                 rrsig_code_idx = int(QTYPE.RRSIG)

--- a/src/foghorn/plugins/resolve/zone_records.py
+++ b/src/foghorn/plugins/resolve/zone_records.py
@@ -200,7 +200,9 @@ class ZoneRecordsConfig(BaseModel):
     dnssec_signing: Optional[ZoneDnssecSigningConfig] = None
 
     class Config:
-        extra = "forbid"
+        # Allow BasePlugin-level options (targets, targets_domains, logging, etc.)
+        # to flow through this typed config model without validation errors.
+        extra = "allow"
 
 
 @plugin_aliases("zone", "zone_records", "custom", "records")

--- a/src/foghorn/plugins/resolve/zone_records.py
+++ b/src/foghorn/plugins/resolve/zone_records.py
@@ -1698,7 +1698,7 @@ class ZoneRecords(BasePlugin):
                 return None
 
             reply = DNSRecord(
-                DNSHeader(id=request.header.id, qr=1, aa=1, ra=1), q=request.q
+                DNSHeader(id=request.header.id, qr=1, aa=1, ra=1, ad=1), q=request.q
             )
             owner = str(request.q.qname).rstrip(".") + "."
 
@@ -1737,7 +1737,7 @@ class ZoneRecords(BasePlugin):
 
         owner = str(request.q.qname).rstrip(".") + "."
         reply = DNSRecord(
-            DNSHeader(id=request.header.id, qr=1, aa=1, ra=1), q=request.q
+            DNSHeader(id=request.header.id, qr=1, aa=1, ra=1, ad=1), q=request.q
         )
 
         rrsets = name_index.get(name, {})

--- a/src/foghorn/utils/ssh_keyscan.py
+++ b/src/foghorn/utils/ssh_keyscan.py
@@ -1,0 +1,194 @@
+from __future__ import annotations
+
+"""Helpers for scanning SSH servers and materializing SSHFP records.
+
+Brief:
+  This module exposes utilities equivalent to ``ssh-keyscan -D`` using
+  Paramiko, returning DNS SSHFP record strings for a single host.
+
+Inputs:
+  - See individual functions for parameters.
+
+Outputs:
+  - Stateless helpers that can be reused from scripts and other modules to
+    obtain SSHFP "<hostname> IN SSHFP <alg> <fptype> <fingerprint>" lines.
+"""
+
+import hashlib
+import logging
+import socket
+from typing import Dict, Iterable, List, Optional, Set, Tuple
+
+import paramiko
+
+
+class _IgnoreIncompatiblePeerLog(logging.Filter):
+    """Brief: Drop Paramiko 'Incompatible ssh peer' log records from stderr.
+
+    Inputs:
+      - record: A logging.LogRecord from the paramiko logger.
+
+    Outputs:
+      - bool: True if the record should be emitted, False if it should be
+        dropped.
+    """
+
+    def filter(self, record: logging.LogRecord) -> bool:  # type: ignore[name-defined]
+        msg = record.getMessage()
+        return "Incompatible ssh peer" not in msg
+
+
+# Attach filter to all Paramiko loggers and silence them to avoid noisy tracebacks.
+_paramiko_root_logger = logging.getLogger("paramiko")
+_paramiko_root_logger.addFilter(_IgnoreIncompatiblePeerLog())
+_paramiko_root_logger.setLevel(logging.CRITICAL)
+
+
+# Common host key algorithms to probe. Extend if needed.
+HOSTKEY_ALGS: List[str] = [
+    "ssh-ed25519",
+    "ssh-ed448",
+    "ecdsa-sha2-nistp256",
+    "ecdsa-sha2-nistp384",
+    "ecdsa-sha2-nistp521",
+    "rsa-sha2-512",
+    "rsa-sha2-256",
+    "ssh-rsa",
+    "ssh-dss",  # legacy DSA
+]
+
+# Mapping from Paramiko key type names to SSHFP algorithm numbers (RFC 4255 / 8709).
+SSHFP_ALG_NUMBERS: Dict[str, int] = {
+    "ssh-rsa": 1,
+    "rsa-sha2-256": 1,
+    "rsa-sha2-512": 1,
+    "ssh-dss": 2,
+    "ecdsa-sha2-nistp256": 3,
+    "ecdsa-sha2-nistp384": 3,
+    "ecdsa-sha2-nistp521": 3,
+    "ssh-ed25519": 4,
+    "ssh-ed448": 6,
+}
+
+
+def fetch_host_key(
+    host: str, port: int, alg: str, timeout: float
+) -> Optional[paramiko.PKey]:
+    """Brief: Connect with one host key algorithm and return the server's key.
+
+    Inputs:
+      - host: Remote SSH server hostname or IP.
+      - port: Remote SSH server port.
+      - alg: Name of host key algorithm to try, e.g. ``ssh-ed25519``.
+      - timeout: Socket and handshake timeout in seconds.
+
+    Outputs:
+      - paramiko.PKey | None: Server key if negotiation succeeds, or None if the
+        algorithm is not supported or the connection fails.
+    """
+
+    sock = None
+    transport = None
+    try:
+        sock = socket.create_connection((host, port), timeout=timeout)
+        transport = paramiko.Transport(sock)
+        opts = transport.get_security_options()
+        # Only offer this specific host key algorithm.
+        opts.key_types = [alg]
+        transport.start_client(timeout=timeout)
+        key = transport.get_remote_server_key()
+        return key
+    except paramiko.ssh_exception.IncompatiblePeer:
+        # Remote side has no acceptable host key for this algorithm; ignore.
+        return None
+    except (paramiko.SSHException, OSError, ValueError):
+        return None
+    finally:
+        if transport is not None:
+            try:
+                transport.close()
+            except Exception:
+                pass
+        if sock is not None:
+            try:
+                sock.close()
+            except Exception:
+                pass
+
+
+def sshfp_records_for_key(
+    hostname: str, key: paramiko.PKey
+) -> List[Tuple[int, int, str]]:
+    """Brief: Compute SSHFP records (algorithm, fptype, hex) for a single key.
+
+    Inputs:
+      - hostname: The DNS name to use in the SSHFP records (not modified here).
+      - key: A Paramiko public key object from ``get_remote_server_key()``.
+
+    Outputs:
+      - list[(algorithm_number, fptype, hex_fingerprint)]:
+          * fptype 1: SHA-1
+          * fptype 2: SHA-256
+        Returns an empty list if the key type is not mapped to an SSHFP
+        algorithm.
+    """
+
+    key_type = key.get_name()
+    alg_num = SSHFP_ALG_NUMBERS.get(key_type)
+    if alg_num is None:
+        return []
+
+    blob = key.asbytes()
+    sha1_hex = hashlib.sha1(blob).hexdigest()
+    sha256_hex = hashlib.sha256(blob).hexdigest()
+
+    return [
+        (alg_num, 1, sha1_hex),
+        (alg_num, 2, sha256_hex),
+    ]
+
+
+def collect_sshfp_records(
+    hostname: str,
+    *,
+    port: int,
+    timeout: float,
+    algs: Iterable[str] | None = None,
+) -> List[str]:
+    """Brief: Probe a host for multiple key algorithms and return SSHFP lines.
+
+    Inputs:
+      - hostname: Remote SSH server hostname to scan.
+      - port: Remote SSH port.
+      - timeout: Connection/handshake timeout in seconds.
+      - algs: Iterable of host key algorithm names to try. When None, uses the
+        default ``HOSTKEY_ALGS`` sequence.
+
+    Outputs:
+      - list[str]: DNS-style SSHFP record strings of the form
+        "<hostname> IN SSHFP <alg> <fptype> <fingerprint>". Duplicate records
+        (same algorithm and fingerprint) are de-duplicated.
+    """
+
+    alg_list: Iterable[str]
+    if algs is None:
+        alg_list = HOSTKEY_ALGS
+    else:
+        alg_list = algs
+
+    seen: Set[Tuple[int, int, str]] = set()
+    lines: List[str] = []
+
+    for alg in alg_list:
+        key = fetch_host_key(hostname, port, alg, timeout)
+        if key is None:
+            continue
+
+        for alg_num, fptype, fp_hex in sshfp_records_for_key(hostname, key):
+            record_id = (alg_num, fptype, fp_hex)
+            if record_id in seen:
+                continue
+            seen.add(record_id)
+            lines.append(f"{hostname} IN SSHFP {alg_num} {fptype} {fp_hex}")
+
+    return lines

--- a/tests/scripts/test_generate_zone_dnssec.py
+++ b/tests/scripts/test_generate_zone_dnssec.py
@@ -92,9 +92,9 @@ www IN  A   192.0.2.2
     # Check that RRSIG records are present.
     assert "RRSIG" in signed_content, "RRSIG not found in signed zone"
 
-    # Check that key files were created.
-    ksk_key = keys_dir / "Kexample_test.ksk.key"
-    zsk_key = keys_dir / "Kexample_test.zsk.key"
+    # Check that key files were created with the new domainkey_<apex> pattern.
+    ksk_key = keys_dir / "domainkey_example_test.ksk.key"
+    zsk_key = keys_dir / "domainkey_example_test.zsk.key"
     assert ksk_key.exists(), "KSK key file not created"
     assert zsk_key.exists(), "ZSK key file not created"
 

--- a/tests/scripts/test_sshfp_scan.py
+++ b/tests/scripts/test_sshfp_scan.py
@@ -1,0 +1,129 @@
+"""Tests for the sshfp_scan CLI wrapper.
+
+Inputs:
+  - None directly; uses monkeypatch and capsys fixtures from pytest.
+
+Outputs:
+  - Verifies that multiple targets (hostnames, IPs, and CIDRs) are expanded
+    correctly and passed to ssh_keyscan.collect_sshfp_records.
+"""
+
+from __future__ import annotations
+
+from typing import List
+
+import pytest
+
+import importlib.util
+import pathlib
+import sys
+
+# Load the sshfp_scan script as a module so we can call main() directly
+_SCRIPTS_DIR = pathlib.Path(__file__).resolve().parents[2] / "scripts"
+_SSHFP_SCAN_PATH = _SCRIPTS_DIR / "sshfp_scan.py"
+
+_spec = importlib.util.spec_from_file_location("sshfp_scan", _SSHFP_SCAN_PATH)
+assert _spec is not None and _spec.loader is not None
+_sshfp_scan = importlib.util.module_from_spec(_spec)
+sys.modules["sshfp_scan"] = _sshfp_scan
+_spec.loader.exec_module(_sshfp_scan)
+
+sshfp_scan = _sshfp_scan
+
+
+class DummyResult:
+    """Brief: Tiny helper to capture calls for assertions.
+
+    Inputs:
+      - hosts: List[str] of hostnames/IPs that were scanned.
+
+    Outputs:
+      - Object with ``hosts`` attribute for inspection in tests.
+    """
+
+    def __init__(self, hosts: List[str]) -> None:
+        self.hosts = hosts
+
+
+def test_multiple_targets_and_cidrs_are_expanded(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """Ensure CLI expands CIDRs and calls collect_sshfp_records per host.
+
+    This test passes multiple targets, including a CIDR, and verifies that
+    ``collect_sshfp_records`` is invoked for each expanded host in order.
+    """
+
+    called_hosts: List[str] = []
+
+    def fake_collect_sshfp_records(*, hostname: str, port: int, timeout: float):  # type: ignore[override]
+        called_hosts.append(hostname)
+        # Return a predictable record to prove we printed something.
+        return [f"{hostname} IN SSHFP 1 1 deadbeef"]
+
+    # Monkeypatch the util function used by the CLI.
+    monkeypatch.setattr(
+        sshfp_scan.ssh_keyscan, "collect_sshfp_records", fake_collect_sshfp_records
+    )
+
+    # 192.0.2.0/30 yields usable hosts 192.0.2.1 and 192.0.2.2
+    argv = [
+        "host1.example",  # hostname
+        "192.0.2.10",  # single IP
+        "192.0.2.0/30",  # CIDR (two usable hosts)
+    ]
+
+    exit_code = sshfp_scan.main(argv)
+    captured = capsys.readouterr()
+
+    assert exit_code == 0
+
+    # We expect host1.example, 192.0.2.10, 192.0.2.1, 192.0.2.2 in this order.
+    assert called_hosts == [
+        "host1.example",
+        "192.0.2.10",
+        "192.0.2.1",
+        "192.0.2.2",
+    ]
+
+    # And at least one SSHFP line per host was printed.
+    for host in called_hosts:
+        assert f"{host} IN SSHFP" in captured.out
+
+
+def test_zone_format_output(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """Brief: --zone-record-format emits pipe-delimited SSHFP records for ZoneRecords.
+
+    Inputs:
+      - monkeypatch: pytest monkeypatch fixture.
+      - capsys: pytest capture fixture.
+
+    Outputs:
+      - Asserts that when --zone-record-format is set, output lines follow
+        "<domain>|SSHFP|<ttl>|<alg> <fptype> <fingerprint>" for each record.
+    """
+
+    def fake_collect_sshfp_records(*, hostname: str, port: int, timeout: float):  # type: ignore[override]
+        assert hostname == "host1.example"
+        return ["host1.example IN SSHFP 1 1 deadbeef"]
+
+    monkeypatch.setattr(
+        sshfp_scan.ssh_keyscan, "collect_sshfp_records", fake_collect_sshfp_records
+    )
+
+    argv = [
+        "--zone-record-format",
+        "--zone-ttl",
+        "600",
+        "host1.example",
+    ]
+
+    exit_code = sshfp_scan.main(argv)
+    captured = capsys.readouterr()
+
+    assert exit_code == 0
+    # Domain should be normalized to lower-case without trailing dot, TTL from
+    # --zone-ttl, and value as "alg fptype fingerprint".
+    assert captured.out.strip() == "host1.example|SSHFP|600|1 1 deadbeef"


### PR DESCRIPTION
So many update and improvements!

The biggest things, imho, are: 
- domain transfers: 
  - now **`AXFR`** transfer is supported over tcp or dot.  
  - tested upstream and downstream with Bind.  (dockerfiles available for testing)
  - No **`IXFR`** support; `IXFR` requests receive `AXFR` answers.  `IXFR` support is waaaay down the priority list.
- DNSSEC made easy!  
  - Just enable and tell it where to store keys.
  - That's it.  Really.
  - Automatically generates keys.
  - RRSIG records are either generated on load or on the fly, depending on setup.
  - Don't forget we made [openssl certs for DoT](https://github.com/zallison/foghorn/blob/main/docs/open-ssl-make-easy.md) easy as well!  Encrypt and sign all the things!
- SSHFP record support.  
  - No more `The authenticity of host 'some.remote.machine' can't be established.` 
  - Make sure `/etc/resolv.conf` uses `options trust-ad.` 
  - Use the SSH option `VerifyHostKeyDNS` .
  - records can be made with openssh's `ssh-keyscan` or the included script `sshfp_scan.py`
- EDE - Extended DNS Errors
  - supports better messaging such as "rate limit" and others.
  - 
    
### Added

- Added configurable DNSSEC signing for zones via a new `ZoneDnssecSigningConfig` block, including algorithm selection, keys directory, enable/disable flag, and validity controls.
- Introduced enhanced DNSSEC-aware behavior in the `resolve.zone_records` plugin, including precomputed mappings for RRsets and RRSIGs and DO-bit-aware responses.
- Added automatic PTR record generation from A/AAAA records in `resolve.zone_records` when configured.
- Added an `sshfp_scan` helper script and `ssh_keyscan` utility module for generating SSHFP records from remote hosts.
- Marked authoritative responses from `resolve.zone_records` as authenticated (AD=1) when they come from signed zones, so DNSSEC-aware stub resolvers and tools like OpenSSH (when combined with `trust-ad`) can rely on them.

### Changed

- Updated the DNSSEC zone signer helper to normalize zone origins, ensure apex nodes exist, and consistently construct DNSKEY and RRSIG RRsets for signed zones.
- Refined `resolve.zone_records` DNSSEC handling so RRSIG and DNSKEY data is surfaced only when appropriate and existing behavior is preserved when DNSSEC helpers are unavailable.
- Improved `resolve.zone_records` DNSSEC answer construction so that, where possible, RRSIGs are attached directly alongside their covered RRsets in the ANSWER section with sensible TTLs.

### Fixed

- Allowed BasePlugin-level options such as `targets`, `targets_domains`, and per-plugin `logging` to flow through the typed `ZoneRecordsConfig` by relaxing its `extra` handling, fixing validation failures for common configs.
- Fixed SOA synthesis and apex inference for SSHFP-only or partial zones so that `resolve.zone_records` can infer a reasonable zone apex and behave authoritatively (including DNSSEC auto-signing) even when no explicit SOA is present.
- Normalized DNSSEC owner names for apex DNSKEY/RRSIG RRsets so that signed material is stored under the real zone apex instead of BIND-style `@` owners, ensuring later lookups can find and serve DNSSEC data correctly.
- Corrected `resolve.zone_records` DNSSEC answer paths so RRSIG records for A/SSHFP and other RRsets are returned in the ANSWER section alongside their covered records and inherit the RRset TTL by default.
- Updated `resolve.zone_records.pre_resolve` to honor BasePlugin client, listener, and domain targeting helpers (`targets`, `targets_listener`, and `targets_domains`), so zone data is only applied to matching queries.

### Tests

- Extended `tests/plugins/test_zone_records.py` to cover DNSSEC mappings, DO-bit behavior, SOA synthesis, automatic PTR generation, and the new targeting/normalization behaviors.
- Added tests for the new `sshfp_scan` script and `ssh_keyscan` utility under `tests/scripts`, validating SSHFP output and error handling.

### Documentation

- Updated Makefile documentation to match current targets and DNSSEC/tooling helpers.
- Refreshed `zone_records` plugin documentation to describe DNSSEC, PTR auto-generation, targeting, and SSHFP interactions.
- Updated Pihole and RFC-style documentation to reflect the new DNSSEC tooling and behavior.
- Documented glibc `trust-ad` behavior in `README.md`, including how to configure `/etc/resolv.conf` so glibc-based applications such as OpenSSH can accept the AD bit from a validating Foghorn instance.

## [0.6.2] - 2026-01-17

> Release notes for changes between **v0.6.1** and **v0.6.2**.

### Added

- Introduced a shared `dnssec.zone_signer` helper module that centralizes DNSKEY/key management, zone signing, and DS record generation for tools and plugins.
- Added optional DNSSEC auto-signing support to the `resolve.zone_records` plugin via a `dnssec_signing` configuration block.
- Extended top-level Makefile targets to drive DNSSEC key and zone signing workflows.
- Added RFC8914 Extended DNS Errors (EDE) support throughout the resolver, controlled by a new `server.enable_ede` flag, and wired into stats snapshots and the admin UI.
- Added AXFR and IXFR support, including a TCP/DoT AXFR transport client, ZoneRecords AXFR integration, and example configs/tests for full-zone transfers.
- Added SSH host key utilities and resolver plugin, SSHFP/OPENPGPKEY record support in zones.
- Added DNSSEC-aware AXFR upstream helpers and signing automation for BIND-style zones consumed by `resolve.zone_records`.

### Changed

- Refactored the `scripts/generate_zone_dnssec.py` into `dnssec.zone_signer`, now it's just a wrapper.
- Tightened DNS server failover, EDNS handling, and DNSSEC validation logging to make error behavior and diagnostics more robust.
- Treated TCP connection resets as short reads in the network stack to reduce spurious errors when clients close connections abruptly.
- Updated packaging metadata, Makefile helpers, and coverage settings to support the new DNSSEC, EDE, and AXFR tooling while keeping CI artifacts out of the tree.

### Documentation

- Updated DNSSEC and zone plugin documentation to describe the new signing helpers and configuration options.
- Documented RFC8914 EDE behavior, how to enable it in configuration, and how it appears in stats and the admin UI.
- Expanded AXFR/IXFR documentation, including examples for ZoneRecords participation in full-zone transfers and DNSSEC-aware AXFR upstreams.
  - IXFR requests are answered with AXFR.
  - No client support for IXFR yet.
- Documented new OpenSSL/SSHFP helpers and resolver plugins, refreshed DNS RFC compliance notes, and updated screenshots and BMC imagery.
- Tweaked README status badges and coverage badge styling.
